### PR TITLE
adding dynamic rules

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -13,8 +13,8 @@ data "http" "get_available_metric_rules" {
 
   # Optional request headers
   request_headers = {
-    Accept = "application/json"
-    DD-API-KEY = var.dd_api_key
+    Accept             = "application/json"
+    DD-API-KEY         = var.dd_api_key
     DD-APPLICATION-KEY = var.dd_app_key
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source = "DataDog/datadog"
-      version = "3.22.0"
+      version = "3.25.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,12 @@ variable "log_collection_services" {
 }
 
 variable "cloudwatch_log_groups_as_list" {
-  default = {}
+  default     = {}
   description = "List of cloudwatch log groups as list."
 }
 
 variable "cloudwatch_log_groups" {
-  default = {}
+  default     = {}
   description = "List of cloudwatch log groups as map."
 }
 


### PR DESCRIPTION
Changing the way `account_specific_namespace_rules` are created.
Up until now only the unwanted rules we're tagged as `false`
but datadog integration by default doesn't mark the once that are not `false` as `true`
Because of that we're marking now what is not `false` is `true`